### PR TITLE
feat: local_to_remote base function 

### DIFF
--- a/build/scripts/worker.sh
+++ b/build/scripts/worker.sh
@@ -24,7 +24,28 @@ remote_to_local() {
     return 1
 }
 
+
+
 # == Function to copy from local to remote ==
+local_to_remote() {
+    local action="$1"
+    local attempt=1
+    local max_attempts="${2:-3}"
+
+    while [ "$attempt" -le "$max_attempts" ]; do
+        echo "Attempt $attempt to $action from /data to $S3_REMOTE:$S3_PATH via rclone..."
+        if rclone $action /data/ "$S3_REMOTE:$S3_PATH" 2>&1; then
+            echo "$action successful."
+            return 0
+        else
+            echo "$action failed on attempt $attempt."
+            attempt=$((attempt + 1))
+            sleep 5
+        fi
+    done
+
+    return 1
+}
 
 # == Main logic ==
 main() {

--- a/build/scripts/worker.sh
+++ b/build/scripts/worker.sh
@@ -3,7 +3,7 @@
 # == File Permissions ==
 #umask 077
 
-# == Function to download with rclone ==
+# == Function to copy from remote to local ==
 remote_to_local() {
     local action="$1"
     local attempt=1

--- a/build/scripts/worker.sh
+++ b/build/scripts/worker.sh
@@ -24,6 +24,8 @@ remote_to_local() {
     return 1
 }
 
+# == Function to copy from local to remote ==
+
 # == Main logic ==
 main() {
     TASK=1 # Future feature


### PR DESCRIPTION
Created a new function called local_to_remote(). It works like the existing remote_to_local() function, but in the opposite direction: instead of downloading files from the remote storage to the local machine, it uploads files from the local directory to the remote storage using rclone.